### PR TITLE
Fix null token bug

### DIFF
--- a/lib/maestro/data/get_session.rb
+++ b/lib/maestro/data/get_session.rb
@@ -14,7 +14,11 @@ module Maestro
           })
         end
 
-        data = JSON.parse(response.body.presence || '{}')
+        if response.body.presence == 'null'
+          data = JSON.parse('{}')
+        else
+          data = JSON.parse(response.body.presence)
+        end
 
         if response.success?
           ::Maestro::Data::Session.new(data.merge(valid: true))

--- a/lib/maestro/data/get_session.rb
+++ b/lib/maestro/data/get_session.rb
@@ -15,7 +15,7 @@ module Maestro
         end
 
         body = response.body
-        data = body == 'null' ? JSON.parse('{}') : JSON.parse(body)
+        data = (body == 'null' || body == '') ? JSON.parse('{}') : JSON.parse(body)
 
         if response.success?
           ::Maestro::Data::Session.new(data.merge(valid: true))

--- a/lib/maestro/data/get_session.rb
+++ b/lib/maestro/data/get_session.rb
@@ -14,11 +14,8 @@ module Maestro
           })
         end
 
-        if response.body.presence == 'null'
-          data = JSON.parse('{}')
-        else
-          data = JSON.parse(response.body.presence)
-        end
+        body = response.body
+        data = body == 'null' ? JSON.parse('{}') : JSON.parse(body)
 
         if response.success?
           ::Maestro::Data::Session.new(data.merge(valid: true))


### PR DESCRIPTION
Fixes the following exception when trying to access KnowledgeAssessment directly (i.e. without establishing a session via a LMS):
```
Exception
----------------
784: unexpected token at 'null'
```

The old line of: `data = JSON.parse(response.body.presence || '{}')`  wasn't working as intended because the Faraday response was returning a body of `'null'` instead of the expected `nil`.  This caused `'null'` to be fed through the JSON parser (instead of `'{}'`), and ultimately led to the parsing error.

A user without a session will now see a 'Not Authenticated' error.