### PR TITLE
Add basic header support

### DIFF
--- a/lib/maestro/data/get_users.rb
+++ b/lib/maestro/data/get_users.rb
@@ -12,8 +12,12 @@ module Maestro
         ensure_successful_response(response)
 
         data = parse_json(response.body)
-        data.fetch('users', [])
+        headers = response.headers
+
+        users = data.fetch('users', [])
           .map { |data| ::Maestro::Data::User.new(data) }
+
+        { headers: headers, users: users }
       end
     end
   end

--- a/spec/maestro/data/get_users_spec.rb
+++ b/spec/maestro/data/get_users_spec.rb
@@ -18,11 +18,13 @@ module Maestro
         expect(request).to have_been_requested
       end
 
-      it 'returns array of User' do
+      it 'returns result hash' do
         request
-          .and_return(body: '{"users": [{"id": 1, "first_name": "User Name"}]}')
-        expect(response).to match_array([kind_of(User)])
-        expect(response.first.first_name).to eq('User Name')
+          .and_return(body: '{"users": [{"id": 1, "first_name": "Name"}]}')
+        expect(response.class).to eq Hash
+        expect(response.keys).to eq [:headers, :users]
+        expect(response[:users]).to match_array([kind_of(User)])
+        expect(response[:users].first.first_name).to eq('Name')
       end
     end
   end


### PR DESCRIPTION
We're going to need access to the headers in either maestro utilities or
assignment workflow to handle api pagination.