### PR TITLE
Add mock_maestro_session spec helper

### DIFF
--- a/lib/maestro/mock_maestro_session.rb
+++ b/lib/maestro/mock_maestro_session.rb
@@ -7,7 +7,7 @@ class MockMaestroSession
   end
 
   def user_id
-    user.id
+    user.lms_u_id
   end
 
   def valid?

--- a/lib/maestro/spec_helpers.rb
+++ b/lib/maestro/spec_helpers.rb
@@ -1,0 +1,7 @@
+require_relative 'mock_maestro_session'
+
+module SpecHelpers
+  def mock_maestro_session(organization, user)
+    MockMaestroSession.new(organization, user)
+  end
+end


### PR DESCRIPTION
I've added a `mock_maestro_session` method to consolidate all of the mocking of maestro sessions to maestro_utilities.

To use it add
`require "maestro/spec_helpers"` to spec/rails_helper.rb
and
`config.include(SpecHelpers)` in the config block of the same file.