### PR TITLE
Add lms_id and app_id to required params for authentication

### DIFF
--- a/lib/maestro/data/get_authentication.rb
+++ b/lib/maestro/data/get_authentication.rb
@@ -3,11 +3,13 @@ module Maestro
     module GetAuthentication
       extend HttpService
 
-      def self.call(session, username, password)
+      def self.call(session, username, password, lms_id, app_id)
         response = Maestro.connection.get do |request|
           request.url '/v1/lms/authentication'
           request.params['username'] = username
           request.params['password'] = password
+          request.params['lms_id'] = lms_id
+          request.params['app_id'] = app_id
         end
         ensure_successful_response(response)
         parse_json(response.body)


### PR DESCRIPTION
Based on the conversation in [this Maestro pull request](https://github.com/VectorLearning/Maestro/pull/53), I've added these params to avoid hard-coding them in Maestro.