### PR TITLE
Setup RedVector student issue submissions

### DIFF
--- a/lib/maestro/data/create_user_issue.rb
+++ b/lib/maestro/data/create_user_issue.rb
@@ -3,14 +3,23 @@ module Maestro
     module CreateUserIssue
       extend HttpService
 
-      def self.call(session, course_id, text)
+      def self.call(session, course_run, issue)
         response = Maestro.connection.post do |request|
-          request.body = JSON.generate({
-            issue: { course_id: course_id, text: text },
-            token: session.token,
-          })
-          request.headers['Content-Type'] = 'application/json'
-          request.url('/v1/lms/profile/issues')
+          request.body = JSON.generate(
+            {
+              issue: {
+                course_id: course_run.course_id,
+                email: session[:lms_data][:email],
+                enrollment_id: course_run.enrollment_id,
+                text: issue[:text],
+                user_id: session[:lms_data][:user_id],
+                url: issue[:url],
+              },
+              token: session.token,
+            }
+          )
+          request.headers["Content-Type"] = "application/json"
+          request.url("/v1/lms/profile/issues")
         end
 
         ensure_successful_response(response)

--- a/lib/maestro/data/create_user_issue.rb
+++ b/lib/maestro/data/create_user_issue.rb
@@ -3,18 +3,18 @@ module Maestro
     module CreateUserIssue
       extend HttpService
 
-      def self.call(session, course_run, issue)
+      def self.call(session, course_id, course_run_id, enrollment_id, issue)
         response = Maestro.connection.post do |request|
           request.body = JSON.generate(
             {
               issue: {
-                course_id: course_run.course_id,
-                email: session[:lms_data][:email],
-                enrollment_id: course_run.enrollment_id,
+                course_id: course_id,
+                course_run_id: course_run_id,
+                enrollment_id: enrollment_id,
                 text: issue[:text],
-                user_id: session[:lms_data][:user_id],
                 url: issue[:url],
               },
+              lms_data: session[:lms_data],
               token: session.token,
             }
           )

--- a/maestro.gemspec
+++ b/maestro.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "pg", "~> 0.18"
+  spec.add_development_dependency "pg", "0.20"
   spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rspec-rails", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 1.0"

--- a/spec/maestro/data/create_user_issue_spec.rb
+++ b/spec/maestro/data/create_user_issue_spec.rb
@@ -4,20 +4,42 @@ module Maestro
   module Data
     RSpec.describe CreateUserIssue do
       let!(:request)  { stub_maestro_request(:post, path).with(body: json) }
-      let(:body)      { {issue: issue, token: token} }
+      let(:issue_params) { { text: "My issue", url:"http://example.com" } }
+      let(:body) do
+        {
+          "issue": {
+            "course_id": course_id,
+            "course_run_id": course_run_id,
+            "enrollment_id": enrollment_id,
+            "text": "My issue",
+            "url": "http://example.com"
+          },
+          "lms_data": [],
+          "token": "token"}
+      end
       let(:course_id) { 1 }
+      let(:course_run_id) { 2 }
+      let(:enrollment_id) { SecureRandom.uuid }
       let(:issue)     { {course_id: course_id, text: text} }
       let(:json)      { JSON.generate(body) }
       let(:path)      { '/v1/lms/profile/issues' }
-      let(:response)  { described_class.call(session, course_id, text) }
+      let(:response)  do
+        described_class.
+          call(session, course_id, course_run_id, enrollment_id, issue_params)
+      end
       let(:session)   { double('Session', token: token) }
       let(:text)      { 'text' }
       let(:token)     { 'token' }
+
+      before(:each) do
+        allow(session).to receive(:[]).with(:lms_data).and_return([])
+      end
 
       it_behaves_like 'an HTTP error handling service'
 
       it 'sends the proper HTTP request' do
         response
+
         expect(request).to have_been_requested
       end
     end


### PR DESCRIPTION
This augments the fields being passed when a student submits an issue while taking a course in CourseManager to provide a little more information (i.e. the CourseRun id, the url they were currently on, the enrollment_id, etc.).  Also, I locked `pg` to `0.20` because I was running into the same issues again.