### PR TITLE
Constrict signature params method

### DIFF
--- a/app/controllers/concerns/maestro/controller_helper.rb
+++ b/app/controllers/concerns/maestro/controller_helper.rb
@@ -44,7 +44,9 @@ module Maestro
     end
 
     def signature_params
-      @signature_params ||= request.query_parameters
+      @signature_params ||= { token: request.query_parameters['token'],
+                              signature: request.query_parameters['signature'],
+                              expires: request.query_parameters['expires'] }
     end
 
     def request_params

--- a/app/controllers/concerns/maestro/controller_helper.rb
+++ b/app/controllers/concerns/maestro/controller_helper.rb
@@ -44,9 +44,7 @@ module Maestro
     end
 
     def signature_params
-      @signature_params ||= { token: request.query_parameters['token'],
-                              signature: request.query_parameters['signature'],
-                              expires: request.query_parameters['expires'] }
+      @signature_params ||= request.query_parameters.slice(:expires, :signature, :token)
     end
 
     def request_params


### PR DESCRIPTION
There will be times where query_parameters will contain information outside signature-specific attributes for Maestro.  Trying to launch from these requests without an already existing valid session will fail.

A good case is the MostMissedQuestionsReport in Knowledge Assessesment, which requires an assessment id.