### PR TITLE
Remove course title requirement for UpdateUserAssessment

### DIFF
--- a/lib/maestro/data/update_user_assessment.rb
+++ b/lib/maestro/data/update_user_assessment.rb
@@ -3,12 +3,11 @@ module Maestro
     module UpdateUserAssessment
       extend HttpService
 
-      def self.call(session, assessment_id, status, topic_results=[], assessment_title="")
+      def self.call(session, assessment_id, status, topic_results=[])
         response = Maestro.connection.put do |request|
           request.body = JSON.generate(status: status,
                                        topic_results: topic_results,
-                                       token: session.token,
-                                       title: assessment_title)
+                                       token: session.token)
           request.headers['Content-Type'] = 'application/json'
           request.url("/v1/lms/profile/assessments/#{assessment_id}")
         end

--- a/spec/maestro/data/update_user_assessment_spec.rb
+++ b/spec/maestro/data/update_user_assessment_spec.rb
@@ -4,14 +4,13 @@ module Maestro
   module Data
     RSpec.describe UpdateUserAssessment do
       let!(:request)        { stub_maestro_request(:put, path).with(body: json) }
-      let(:body)            { {status: status, topic_results: topic_results, token: token, title: title} }
+      let(:body)            { {status: status, topic_results: topic_results, token: token} }
       let(:status)          { 'complete' }
       let(:topic_results)   { { topics: [ { id: 1, name: 'topic name', benchmark_percentage: '80', score_percentage: '70', met: 'false' } ] } }
       let(:id)              { 1 }
-      let(:title)           { 'Dummy Assessment' }
       let(:json)            { JSON.generate(body) }
       let(:path)            { "/v1/lms/profile/assessments/#{id}" }
-      let(:response)        { described_class.call(session, id, status, topic_results, title) }
+      let(:response)        { described_class.call(session, id, status, topic_results) }
       let(:session)         { double('Session', token: token) }
       let(:token)           { 'token' }
 


### PR DESCRIPTION
The LMS should be able to determine any assessment attribute from its id.

# Conflicts:
#	lib/maestro/data/update_user_assessment.rb