### PR TITLE
fix rollbar two-fitty

### DIFF
--- a/app/helpers/maestro/session_helper.rb
+++ b/app/helpers/maestro/session_helper.rb
@@ -6,18 +6,18 @@ module ::Maestro
     end
 
     def navigation_stylesheet
-      if custom_theme
-        "maestro/themes/custom/#{custom_theme}_theme"
-      else
+      if custom_theme.blank?
         "maestro/themes/#{maestro_session.lms_id.downcase}_theme"
+      else
+        "maestro/themes/custom/#{custom_theme}_theme"
       end
     end
 
     def navigation_javascript
-      if custom_theme
-        "maestro/components/custom/#{custom_theme}/components"
-      else
+      if custom_theme.blank?
         "maestro/components/#{maestro_session.lms_id.downcase}/components"
+      else
+        "maestro/components/custom/#{custom_theme}/components"
       end
     end
 


### PR DESCRIPTION
Don't pull a stylesheet/javascript if `custom_theme` is passed as anything other than a string.

Fixes the following:
https://rollbar.com/knowledge-assessment-prod/knowledge-assessment-prod/items/250/?item_page=0&#instances
